### PR TITLE
Parameters to command "fc" are given wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Copy - Paste
 ```
-fc -l 1 | awk '{CMD[$2]++;count++;}END { for (a in CMD)print CMD[a] " " CMD[a]/count*100 "% " a; }' | grep -v "./" | column -c3 -s " " -t | sort -nr | nl | head -n15
+fc -l | awk '{CMD[$2]++;count++;}END { for (a in CMD)print CMD[a] " " CMD[a]/count*100 "% " a; }' | grep -v "./" | column -c3 -s " " -t | sort -nr | nl | head -n15
 ```
 > 08.04.2017 
    ```


### PR DESCRIPTION
The parameters to fc are given as:
fc -l 1
but it should be:
fc -l
Otherwise it produces the following error:
bash: fc: history specification out of range